### PR TITLE
Fix titles coming from link preview

### DIFF
--- a/src/lemmy/service/getPostURLPreview.ts
+++ b/src/lemmy/service/getPostURLPreview.ts
@@ -13,10 +13,6 @@ export async function getPostURLPreview(post: Post): Promise<Post> {
     const response = await getLinkPreview(post.url, { headers });
     const linkPreview = response as LinkPreview;
 
-    if (linkPreview.title) {
-      postDeepCopy.title = linkPreview.title;
-    }
-
     if (linkPreview.description) {
       postDeepCopy.content = linkPreview.description;
     }


### PR DESCRIPTION
Some links from link preview don't have any titles as mentioned on issue #20 
Changing back to reddit titles for now, this closes #20.